### PR TITLE
changed port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,19 @@ resource "aws_security_group" "webserver" {
     ipv6_cidr_blocks = [ "::/0" ]
   }
 
-    
+
+## New change by dev
+
+  ingress {
+    description      = ""
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [ "0.0.0.0/0" ]
+    ipv6_cidr_blocks = [ "::/0" ]
+  }
+
+
   egress {
     from_port        = 0
     to_port          = 0


### PR DESCRIPTION
[root@ip-172-31-9-244 zomato-project]# terraform plan
aws_security_group.webserver: Refreshing state... [id=sg-0ebf1df283908f0d2]
aws_security_group.remote: Refreshing state... [id=sg-074cfb2968470c9c7]
aws_s3_bucket.statefile: Refreshing state... [id=zomato-statefile]
aws_instance.application: Refreshing state... [id=i-0b65de1c75f9a654d]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_security_group.webserver will be updated in-place
  ~ resource "aws_security_group" "webserver" {
        id                     = "sg-0ebf1df283908f0d2"
      ~ ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 443
              + ipv6_cidr_blocks = [
                  + "::/0",
                ]
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
            # (1 unchanged element hidden)
        ]
        name                   = "webserver"
        tags                   = {
            "Name"    = "webserver-zomato"
            "project" = "zomato"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
